### PR TITLE
Fix issue read groups

### DIFF
--- a/modules/01_prepare_bam.nf
+++ b/modules/01_prepare_bam.nf
@@ -30,27 +30,26 @@ process PREPARE_BAM {
     """
     mkdir tmp
 
-    gatk CleanSam \
-    --java-options '-Xmx${params.prepare_bam_memory} -Djava.io.tmpdir=tmp' \
-    --INPUT ${bam} \
-    --OUTPUT /dev/stdout | \
-    gatk ReorderSam \
-    --java-options '-Xmx${params.prepare_bam_memory} -Djava.io.tmpdir=tmp' \
-    --INPUT /dev/stdin \
-    --OUTPUT /dev/stdout \
-    --SEQUENCE_DICTIONARY ${params.reference} | \
     gatk AddOrReplaceReadGroups \
     --java-options '-Xmx${params.prepare_bam_memory} -Djava.io.tmpdir=tmp' \
     --VALIDATION_STRINGENCY SILENT \
-    --INPUT /dev/stdin \
-    --OUTPUT ${name}.prepared.bam \
+    --INPUT ${bam} \
+    --OUTPUT /dev/stdout \
     --REFERENCE_SEQUENCE ${params.reference} \
     --RGPU 1 \
     --RGID 1 \
     --RGSM ${type} \
     --RGLB 1 \
-    --RGPL ${params.platform} \
-    ${order}
+    --RGPL ${params.platform} ${order} | \
+    gatk CleanSam \
+    --java-options '-Xmx${params.prepare_bam_memory} -Djava.io.tmpdir=tmp' \
+    --INPUT /dev/stdin \
+    --OUTPUT /dev/stdout | \
+    gatk ReorderSam \
+    --java-options '-Xmx${params.prepare_bam_memory} -Djava.io.tmpdir=tmp' \
+    --INPUT /dev/stdin \
+    --OUTPUT ${name}.prepared.bam \
+    --SEQUENCE_DICTIONARY ${params.reference}
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,7 +46,7 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 
 cleanup = true
 
-VERSION = '1.7.0'
+VERSION = '1.7.1'
 DOI = 'https://zenodo.org/badge/latestdoi/358400957'
 
 manifest {


### PR DESCRIPTION
It was found an issue with some BAMs with a header with an empty SM tag such as:
```
@RG     ID:0210_010_CE_NOR_PGDP_EL2_S16_L001_R1_001-pooled.fastq.gz     SM:
```

The call to AddOrReplaceReadGroups fixes this but it was being called after some other stuff, so the order of execution has been changed to avoid this.